### PR TITLE
Fix formatting of first exercise in range_intro.md

### DIFF
--- a/content/post/2019/11/30 - range_intro.md
+++ b/content/post/2019/11/30 - range_intro.md
@@ -233,6 +233,7 @@ Both take a invocable as argument, e.g. a lambda expression.
 
 <details style='border:1px solid; padding: 2px; margin: 2px'>
   <summary><i>Here is the solution</i></summary>
+
 ```cpp
 std::vector vec{1, 2, 3, 4, 5, 6};
 auto v = vec


### PR DESCRIPTION
Inside of a \<details> section, the **```cpp** markup is not recognized without a preceding empty line. This change adds the needed empty line in the solution to the first exercise, where it's absence was causing the remainder of the document to be improperly formatted.